### PR TITLE
feat: Update workspace command

### DIFF
--- a/client/client/workspace.go
+++ b/client/client/workspace.go
@@ -1,9 +1,9 @@
 package client
 
 import (
-	"terrakube/client/models"
 	"fmt"
 	"net/http"
+	"terrakube/client/models"
 )
 
 type WorkspaceClient struct {
@@ -11,7 +11,7 @@ type WorkspaceClient struct {
 }
 
 func (c *WorkspaceClient) List(organizationId string, filter string) ([]*models.Workspace, error) {
-	req, err := c.Client.newRequest(http.MethodGet, fmt.Sprintf("organization/%v/workspace", organizationId), nil)
+	req, err := c.Client.newRequestWithFilter(http.MethodGet, fmt.Sprintf("organization/%v/workspace", organizationId), filter, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/models/workspace.go
+++ b/client/models/workspace.go
@@ -32,11 +32,23 @@ type WorkspaceAttributes struct {
 	// name
 	Name string `json:"name,omitempty"`
 
+	// description
+	Description string `json:"description,omitempty"`
+
 	// source
 	Source string `json:"source,omitempty"`
 
+	// folder
+	Folder string `json:"folder,omitempty"`
+
+	// Execution mode
+	ExecutionMode string `json:"executionMode,omitempty"`
+
 	// branch
 	Branch string `json:"branch,omitempty"`
+
+	// IaC type
+	IacType string `json:"iacType,omitempty"`
 
 	// terraformVersion
 	TerraformVersion string `json:"terraformVersion,omitempty"`

--- a/cmd/workspace_create.go
+++ b/cmd/workspace_create.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"terrakube/client/models"
 	"fmt"
+	"terrakube/client/models"
 
 	"github.com/spf13/cobra"
 )
@@ -11,14 +11,27 @@ var WorkspaceCreateExample string = `Create a new workspace
     %[1]v workspace create --organization-id 312b4415-806b-47a9-9452-b71f0753136e -n myWorkspace -s https://github.com/terrakube-io/terraform-sample-repository.git -b master -t 0.15.0`
 
 var WorkspaceCreateName string
+var WorkspaceDescription string
+var WorkspaceCreateIacType string
+var WorkspaceCreateFolder string
+var WorkspaceExecutionMode string
 var WorkspaceCreateSource string
 var WorkspaceCreateBranch string
-var WorkspaceCreateTerraformV string
+var WorkspaceCreateCli bool
+var WorkspaceCreateIacV string
 var WorkspaceCreateOrgId string
 var createWorkspaceCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a workspace",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Adjust branch/source based on CLI flag after flags are parsed
+		if WorkspaceCreateCli {
+			fmt.Println("Creating cli workspace")
+			WorkspaceCreateBranch = "remote-content"
+			WorkspaceCreateSource = "empty"
+		} else {
+			fmt.Println("Creating vcs workspace")
+		}
 		createWorkspace()
 	},
 	Example: fmt.Sprintf(WorkspaceCreateExample, rootCmd.Use),
@@ -32,7 +45,12 @@ func init() {
 	_ = createWorkspaceCmd.MarkFlagRequired("organization-id")
 	createWorkspaceCmd.Flags().StringVarP(&WorkspaceCreateBranch, "branch", "b", "", "Branch of the new workspace")
 	createWorkspaceCmd.Flags().StringVarP(&WorkspaceCreateSource, "source", "s", "", "Source of the new workspace")
-	createWorkspaceCmd.Flags().StringVarP(&WorkspaceCreateTerraformV, "terraform-version", "t", "", "Terraform Version use in the new workspace")
+	createWorkspaceCmd.Flags().StringVarP(&WorkspaceCreateIacV, "iac-version", "v", "", "Terraform/tofu Version use in the new workspace")
+	createWorkspaceCmd.Flags().StringVarP(&WorkspaceCreateFolder, "folder", "f", "/", "Folder of the new workspace")
+	createWorkspaceCmd.Flags().StringVarP(&WorkspaceExecutionMode, "execution-mode", "e", "remote", "Execution mode for workspace")
+	createWorkspaceCmd.Flags().StringVarP(&WorkspaceCreateIacType, "iac-type", "t", "terraform", "IAC Type for workspace")
+	createWorkspaceCmd.Flags().StringVarP(&WorkspaceDescription, "description", "d", "", "Description of the new workspace")
+	createWorkspaceCmd.Flags().BoolVarP(&WorkspaceCreateCli, "cli", "c", false, "Create a CLI workspace")
 }
 
 func createWorkspace() {
@@ -41,9 +59,13 @@ func createWorkspace() {
 	workspace := models.Workspace{
 		Attributes: &models.WorkspaceAttributes{
 			Name:             WorkspaceCreateName,
+			Description:      WorkspaceDescription,
+			Folder:           WorkspaceCreateFolder,
 			Source:           WorkspaceCreateSource,
 			Branch:           WorkspaceCreateBranch,
-			TerraformVersion: WorkspaceCreateTerraformV,
+			IacType:          WorkspaceCreateIacType,
+			ExecutionMode:    WorkspaceExecutionMode,
+			TerraformVersion: WorkspaceCreateIacV,
 		},
 		Type: "workspace",
 	}

--- a/cmd/workspace_update.go
+++ b/cmd/workspace_update.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"terrakube/client/models"
 	"fmt"
+	"terrakube/client/models"
 
 	"github.com/spf13/cobra"
 )
@@ -16,6 +16,10 @@ var WorkspaceUpdateBranch string
 var WorkspaceUpdateTerraformV string
 var WorkspaceUpdateOrgId string
 var WorkspaceUpdateId string
+var WorkspaceUpdateDescription string
+var WorkspaceUpdateFolder string
+var WorkspaceUpdateIacType string
+var WorkspaceUpdateExecutionMode string
 
 var updateWorkspaceCmd = &cobra.Command{
 	Use:   "update",
@@ -35,7 +39,11 @@ func init() {
 	_ = updateWorkspaceCmd.MarkFlagRequired("id")
 	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateBranch, "branch", "b", "", "Branch of the workspace")
 	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateSource, "source", "s", "", "Source of the workspace")
-	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateTerraformV, "terraform-version", "t", "", "Terraform Version use in the workspace")
+	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateTerraformV, "iac-version", "v", "", "terraform/tofu Version use in the workspace")
+	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateDescription, "description", "d", "", "Workspace description")
+	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateFolder, "folder", "f", "/", "Workspace folder")
+	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateExecutionMode, "execution-mode", "e", "remote", "Workspace execution mode")
+	updateWorkspaceCmd.Flags().StringVarP(&WorkspaceUpdateIacType, "iac-type", "t", "terraform", "Iac type")
 }
 
 func updateWorkspace() {
@@ -44,6 +52,10 @@ func updateWorkspace() {
 	workspace := models.Workspace{
 		Attributes: &models.WorkspaceAttributes{
 			Name:             WorkspaceUpdateName,
+			Description:      WorkspaceUpdateDescription,
+			Folder:           WorkspaceUpdateFolder,
+			IacType:          WorkspaceUpdateIacType,
+			ExecutionMode:    WorkspaceExecutionMode,
 			Branch:           WorkspaceUpdateBranch,
 			Source:           WorkspaceUpdateSource,
 			TerraformVersion: WorkspaceUpdateTerraformV,


### PR DESCRIPTION
Updating the workspace command with new fields

To create a cli-drive workflow it can be used like this
```
 terrakube workspace create --name cli --description helloworld --cli --organization-id d9b58bd3-f3fc-4056-a026-1163297e80a8 --iac-type tofu --iac-version 1.8.0
```

To create a vcs drive workflow it can be used like this:

```
 terrakube workspace list --organization-id d9b58bd3-f3fc-4056-a026-1163297e80a8 --output table
 terrakube workspace create --name cli2 --description helloworld --organization-id d9b58bd3-f3fc-4056-a026-1163297e80a8 --iac-type tofu --iac-version 1.8.0 --branch main --source https://github.com/AzBuilder/terrakube-docker-compose.git
```