### PR TITLE
fix(resource): accept raw non-UUID IDs for job parent scope

### DIFF
--- a/cmd/address.go
+++ b/cmd/address.go
@@ -31,6 +31,7 @@ func init() {
 				Flag:      "job",
 				ShortFlag: "j",
 				IDFlag:    "job-id",
+				RawID:     true,
 			},
 		},
 		Fields: []resource.FieldDef{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,7 +170,7 @@ func formatFieldValue(fieldValue reflect.Value) string {
 	switch fieldValue.Kind() {
 	case reflect.Bool:
 		return fmt.Sprintf("%t", fieldValue.Bool())
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if fieldValue.IsNil() {
 			return ""
 		}

--- a/cmd/step.go
+++ b/cmd/step.go
@@ -31,6 +31,7 @@ func init() {
 				Flag:      "job",
 				ShortFlag: "j",
 				IDFlag:    "job-id",
+				RawID:     true,
 			},
 		},
 		Fields: []resource.FieldDef{

--- a/internal/resource/resolve.go
+++ b/internal/resource/resolve.go
@@ -11,6 +11,7 @@ import (
 
 // resolveParents resolves parent resource IDs from flags.
 // Each parent's unified flag accepts either a UUID (used directly) or a name (resolved via Resolver).
+// Parents with RawID set (e.g. jobs, whose IDs are numeric) use the flag value as the ID directly.
 func resolveParents(ctx context.Context, client *terrakube.Client, cmd *cobra.Command, parents []ParentScope) ([]string, error) {
 	ids := make([]string, 0, len(parents))
 
@@ -31,7 +32,7 @@ func resolveParent(ctx context.Context, client *terrakube.Client, cmd *cobra.Com
 		return "", fmt.Errorf("--%s is required", p.Flag)
 	}
 
-	if IsUUID(val) {
+	if p.RawID || IsUUID(val) {
 		return val, nil
 	}
 

--- a/internal/resource/resolve_test.go
+++ b/internal/resource/resolve_test.go
@@ -183,3 +183,47 @@ func TestResolveParents_ResolverError(t *testing.T) {
 		t.Errorf("unexpected error: %v", got)
 	}
 }
+
+func TestResolveParents_RawIDPassthrough(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("job", "", "")
+	_ = cmd.Flags().Set("job", "35")
+
+	parents := []ParentScope{{
+		Name: "job", Flag: "job", IDFlag: "job-id", RawID: true,
+	}}
+
+	ids, err := resolveParents(context.Background(), nil, cmd, parents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "35" {
+		t.Errorf("expected raw ID passthrough, got %v", ids)
+	}
+}
+
+func TestResolveParents_RawIDSkipsResolver(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("job", "", "")
+	_ = cmd.Flags().Set("job", "35")
+
+	called := false
+	parents := []ParentScope{{
+		Name: "job", Flag: "job", IDFlag: "job-id", RawID: true,
+		Resolver: func(_ context.Context, _ *terrakube.Client, _ []string, _ string) (string, error) {
+			called = true
+			return "resolved", nil
+		},
+	}}
+
+	ids, err := resolveParents(context.Background(), nil, cmd, parents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ids[0] != "35" {
+		t.Errorf("expected raw ID passthrough, got %s", ids[0])
+	}
+	if called {
+		t.Error("resolver should not be called for RawID parent")
+	}
+}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -29,6 +29,7 @@ type ParentScope struct {
 	ShortFlag string   // short flag, e.g. "o"
 	Aliases   []string // flag aliases, e.g. ["org"]
 	IDFlag    string   // hidden backwards-compat alias, e.g. "organization-id"
+	RawID     bool     // parent IDs are not UUIDs (e.g. numeric job IDs); use the flag value as the ID directly, no name resolution
 	Resolver  func(ctx context.Context, c *terrakube.Client, resolvedParentIDs []string, name string) (string, error)
 }
 
@@ -257,7 +258,11 @@ func newDeleteCmd[T any](cfg Config[T]) *cobra.Command {
 func addParentFlags(cmd *cobra.Command, parents []ParentScope) {
 	aliases := make(map[string]string)
 	for _, p := range parents {
-		cmd.Flags().StringP(p.Flag, p.ShortFlag, "", fmt.Sprintf("%s ID or name", p.Name))
+		usage := fmt.Sprintf("%s ID or name", p.Name)
+		if p.RawID {
+			usage = fmt.Sprintf("%s ID", p.Name)
+		}
+		cmd.Flags().StringP(p.Flag, p.ShortFlag, "", usage)
 		if p.IDFlag != "" && p.IDFlag != p.Flag {
 			aliases[p.IDFlag] = p.Flag
 		}


### PR DESCRIPTION
Fixes #53.

### Problem

Job IDs are numeric strings (e.g. `35`), never UUIDs, but `resolveParent` accepts only UUIDs unless a name resolver is configured, and the `job` parent scope has none. As a result every `step` and `address` subcommand is unusable:

```console
$ terrakube step list -o myorg -j 35
Error: --job: "35" is not a valid UUID and name resolution is not configured for job
```

### Fix

Add `ParentScope.RawID` for parents whose IDs are not UUIDs and which have no names to resolve. When set, the flag value is used as the ID directly. The `job` parent scope in `cmd/step.go` and `cmd/address.go` sets it, and the generated `--job` flag help becomes `job ID` instead of `job ID or name`.

### Testing

- New unit tests: `TestResolveParents_RawIDPassthrough`, `TestResolveParents_RawIDSkipsResolver`.
- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass.
- Verified against a live Terrakube 2.x server: `terrakube step list -o <org> -j 35` now returns the job's steps; before the change it failed with the error above.
